### PR TITLE
Alter url to be a variable and optional under configuration path

### DIFF
--- a/Sources/CheckoutNetwork/ConfigurationModels/Path.swift
+++ b/Sources/CheckoutNetwork/ConfigurationModels/Path.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Shared interface for generating an url from your structure grouping your endpoints
 public protocol NetworkPath {
-    
-    /// URL to be used for creation of a network request
-    func url() -> URL
+  
+  /// URL to be used for creation of a network request
+  var url: URL? { get }
 }

--- a/Sources/CheckoutNetwork/ConfigurationModels/RequestConfiguration.swift
+++ b/Sources/CheckoutNetwork/ConfigurationModels/RequestConfiguration.swift
@@ -30,7 +30,8 @@ public struct RequestConfiguration {
                 mimeType: MIMEType = .JSON,
                 decodingStrategy: JSONDecoder.KeyDecodingStrategy = .useDefaultKeys) throws {
         // Validate URL can be broken down to components for formatting
-        guard var components = URLComponents(url: path.url(), resolvingAgainstBaseURL: true) else {
+        guard let url = path.url,
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: true) else {
             throw CheckoutNetworkError.invalidURL
         }
         

--- a/Tests/CheckoutNetworkTests/CheckoutNetworkClientTests.swift
+++ b/Tests/CheckoutNetworkTests/CheckoutNetworkClientTests.swift
@@ -88,7 +88,7 @@ final class CheckoutNetworkClientTests: XCTestCase {
         let testResponseCode = 300
         
         let expectedData = "nothing".data(using: .utf8)
-        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url(),
+        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url!,
                                                statusCode: 300,
                                                httpVersion: nil,
                                                headerFields: nil)
@@ -142,7 +142,7 @@ final class CheckoutNetworkClientTests: XCTestCase {
         let client = CheckoutNetworkClient(session: fakeSession)
         let testConfig = try! RequestConfiguration(path: FakePath.testServices)
         
-        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url(),
+        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url!,
                                                statusCode: 200,
                                                httpVersion: nil,
                                                headerFields: nil)
@@ -171,7 +171,7 @@ final class CheckoutNetworkClientTests: XCTestCase {
         let testConfig = try! RequestConfiguration(path: FakePath.testServices)
         
         let expectedData = Data()
-        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url(),
+        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url!,
                                                statusCode: 200,
                                                httpVersion: nil,
                                                headerFields: nil)
@@ -205,7 +205,7 @@ final class CheckoutNetworkClientTests: XCTestCase {
         let fakeObjectString = String(data: fakeObjectEncoded, encoding: .utf8)!
         // Make id key invalid for decoding
         fakeObjectEncoded = fakeObjectString.replacingOccurrences(of: "d", with: "").data(using: .utf8)!
-        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url(),
+        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url!,
                                                statusCode: 200,
                                                httpVersion: nil,
                                                headerFields: nil)
@@ -236,7 +236,7 @@ final class CheckoutNetworkClientTests: XCTestCase {
         
         let fakeObject = FakeObject(id: UUID().uuidString)
         let fakeObjectEncoded = try! JSONEncoder().encode(fakeObject)
-        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url(),
+        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url!,
                                                statusCode: 200,
                                                httpVersion: nil,
                                                headerFields: nil)
@@ -289,7 +289,7 @@ final class CheckoutNetworkClientTests: XCTestCase {
         let testResponseCode = 300
         
         let expectedData = "nothing".data(using: .utf8)
-        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url(),
+        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url!,
                                                statusCode: 300,
                                                httpVersion: nil,
                                                headerFields: nil)
@@ -335,7 +335,7 @@ final class CheckoutNetworkClientTests: XCTestCase {
         
         let fakeObject = FakeObject(id: UUID().uuidString)
         let fakeObjectEncoded = try! JSONEncoder().encode(fakeObject)
-        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url(),
+        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url!,
                                                statusCode: 200,
                                                httpVersion: nil,
                                                headerFields: nil)
@@ -358,7 +358,7 @@ final class CheckoutNetworkClientTests: XCTestCase {
         let client = CheckoutNetworkClient(session: fakeSession)
         let testConfig = try! RequestConfiguration(path: FakePath.testServices)
         
-        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url(),
+        let expectedResponse = HTTPURLResponse(url: FakePath.testServices.url!,
                                                statusCode: 200,
                                                httpVersion: nil,
                                                headerFields: nil)

--- a/Tests/CheckoutNetworkTests/Helpers/FakePath.swift
+++ b/Tests/CheckoutNetworkTests/Helpers/FakePath.swift
@@ -12,7 +12,7 @@ enum FakePath: NetworkPath {
     
     case testServices
     
-    func url() -> URL {
+    var url: URL? {
         switch self {
         case .testServices: return URL(string: "https://google-not.now")!
         }

--- a/Tests/CheckoutNetworkTests/RequestConfigurationTests.swift
+++ b/Tests/CheckoutNetworkTests/RequestConfigurationTests.swift
@@ -15,7 +15,7 @@ final class RequestConfigurationTests: XCTestCase {
         let config = try! RequestConfiguration(path: testPath)
         let request = config.request
         
-        XCTAssertEqual(request.url, testPath.url())
+        XCTAssertEqual(request.url, testPath.url)
         XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
         XCTAssertNil(request.httpBody)
         XCTAssertEqual(request.allHTTPHeaderFields, [:])
@@ -29,7 +29,7 @@ final class RequestConfigurationTests: XCTestCase {
                                                mimeType: testMime)
         let request = config.request
         
-        XCTAssertEqual(request.url, testPath.url())
+        XCTAssertEqual(request.url, testPath.url)
         XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
         XCTAssertNil(request.httpBody)
         XCTAssertEqual(request.allHTTPHeaderFields, [:])
@@ -44,7 +44,7 @@ final class RequestConfigurationTests: XCTestCase {
                                                mimeType: testMime)
         let request = config.request
         
-        XCTAssertEqual(request.url, testPath.url())
+        XCTAssertEqual(request.url, testPath.url)
         XCTAssertEqual(request.httpMethod, HTTPMethod.get.rawValue)
         XCTAssertEqual(request.httpBody, testData)
         XCTAssertEqual(request.allHTTPHeaderFields, [MIMEType.key: testMime.rawValue])


### PR DESCRIPTION
We needed this to avoid having SDK crash with `fatalError` in the case where a URL could not be created. Now, the clients of `CheckoutNetwork` will get an error thrown in this case so that they can gracefully handle it. Also, it's harder to test `fatalError` than to test thrown `Error` conformers in Swift.