### PR TITLE
Fix CheckoutNetworkFakeClient

### DIFF
--- a/Sources/CheckoutNetwork/ConfigurationModels/RequestConfiguration.swift
+++ b/Sources/CheckoutNetwork/ConfigurationModels/RequestConfiguration.swift
@@ -12,7 +12,7 @@ public struct RequestConfiguration {
     
     /// Request created from the consumers configuration
     private(set) public var request: URLRequest
-    var decodingStrategy: JSONDecoder.KeyDecodingStrategy
+    private(set) public var decodingStrategy: JSONDecoder.KeyDecodingStrategy
 
     /// Create request configuration with provided parameters. In case of failure will throw a `CheckoutNetworkError`
     ///

--- a/Sources/CheckoutNetworkFakeClient/CheckoutNetworkFakeClient.swift
+++ b/Sources/CheckoutNetworkFakeClient/CheckoutNetworkFakeClient.swift
@@ -12,7 +12,7 @@ final public class CheckoutNetworkFakeClient: CheckoutClientInterface {
     public var calledRequests: [(config: RequestConfiguration, completion: Any)] = []
 
     public var calledAsyncRequests: [RequestConfiguration] = []
-    public var dataToBeReturned: Decodable!
+    public var dataToBeReturned: Data!
     public var errorToBeThrown: CheckoutNetworkError?
 
     public func runRequest<T: Decodable>(with configuration: RequestConfiguration,
@@ -31,7 +31,10 @@ extension CheckoutNetworkFakeClient {
       calledAsyncRequests.append(configuration)
       // swiftlint:disable force_cast
       guard let error = errorToBeThrown else {
-        return dataToBeReturned as! T
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = configuration.decodingStrategy
+        let decoded = try decoder.decode(T.self, from: dataToBeReturned)
+        return decoded
       }
       throw error
       // swiftlint:enable force_cast


### PR DESCRIPTION
CheckoutNetworkFakeClient's `dataToBeReturned` property was not being used and was not working as expected. This PR fixes it by adding a decoder.